### PR TITLE
getTermByIRIId() fix

### DIFF
--- a/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
@@ -39,10 +39,8 @@ public class OLSClientTest {
     }
 
     @Test
-    @Ignore
-    //Ignoring as test takes a long time to complete
     public void testGetAllTermsFromOntology() throws Exception {
-        List<Term> terms = olsClient.getAllTermsFromOntology("ms");
+        List<Term> terms = olsClient.getAllTermsFromOntology("pride");
         logger.info(terms.toString());
         Assert.assertTrue(terms.size() > 0);
     }

--- a/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
@@ -26,13 +26,10 @@ public class OLSClientTest {
     private static final Logger logger = LoggerFactory.getLogger(OLSClientTest.class);
 
     @Test
-    @Ignore
-    //Ignoring as test uses ontology label that may change and break the test
     public void testGetTermById() throws Exception {
         Term term = olsClient.getTermById(new Identifier("MS:1001767", Identifier.IdentifierType.OBO), "MS");
-        Assert.assertTrue(term.getLabel().equalsIgnoreCase("nanoACQUITY UPLC System with 1D Technology"));
+        Assert.assertTrue(term.getTermOBOId().getIdentifier().equalsIgnoreCase("MS:1001767"));
     }
-
 
     @Test
     public void testGetOntologyNames() throws Exception {

--- a/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
+++ b/src/test/java/uk/ac/ebi/pride/utilities/ols/web/service/client/OLSClientTest.java
@@ -320,4 +320,11 @@ public class OLSClientTest {
         term = olsClient.getReplacedBy(id);
         assertNull(term);
     }
+
+    @Test
+    public void testGetTermByIriId() throws Exception {
+        Term term = olsClient.getTermById(new Identifier("GO:0031145", Identifier.IdentifierType.OBO), "GO");
+        term = olsClient.getTermByIRIId(term.getIri().getIdentifier(), term.getOntologyPrefix());
+        Assert.assertTrue(term.getTermOBOId().getIdentifier().equalsIgnoreCase("GO:0031145"));
+    }
 }


### PR DESCRIPTION
Hi,

I was trying to use OLS Client to look up terms via IRI ID and it wasn't working properly. Then I remembered you should are taking care of this library now, so the changes should go here.

I have fixed the getTermByIRIId() method which wasn't working at all properly before, mainly due to the character encoding required within the IRI ID. I've also included a new unit test for the revised method to easily test it and improve coverage.

I also noticed 2 unit tests were ignored - I've made small changes so that they would be OK now in terms of what they check for and speed of execution. Hopefully they don't need to be ignored any more.

Thanks,
Tobias